### PR TITLE
tcl_server: Include time.h.

### DIFF
--- a/tcl_server.c
+++ b/tcl_server.c
@@ -13,6 +13,7 @@ specific language governing permissions and limitations under the License. */
 #include <linux/spi/spidev.h>
 #include <linux/types.h>
 #include <stdio.h>
+#include <time.h>
 #include <sys/ioctl.h>
 #include "opc.h"
 


### PR DESCRIPTION
time.h was missing from tcl_server.c which caused time_t to be undefined which resulted in tcl_server failing to compile in my environment.
