### PR TITLE
Add -lm and place linked libraries after object on gcc cmdline.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifeq ($(platform),Darwin)
   GL_OPTS=-framework OpenGL -framework GLUT
 else ifeq ($(platform),Linux)
   ALL=bin/dummy_client bin/dummy_server bin/tcl_server bin/ws2801_server bin/lpd8806_server bin/gl_server
-  GL_OPTS=-lGL -lglut -lGLU
+  GL_OPTS=-lGL -lglut -lGLU -lm
 endif
 
 all: $(ALL)
@@ -35,4 +35,4 @@ bin/lpd8806_server: src/lpd8806_server.c src/opc_server.c src/spi.c
 
 bin/gl_server: src/gl_server.c src/opc_server.c src/cJSON.c
 	mkdir -p bin
-	gcc $(GL_OPTS) -o $@ $^
+	gcc -o $@ $^ $(GL_OPTS)


### PR DESCRIPTION
On Ubuntu 13.04 with gcc 4.7.3 it requires libraries to be specified after objects on the command line. Otherwise you'll get lots of undefined references.

Also added missing math library.
