### PR TITLE
Updated example_clients to python_client to reflect the folder structure

### DIFF
--- a/python_clients/example.py
+++ b/python_clients/example.py
@@ -13,7 +13,7 @@ First start the gl simulator using, for example, the included "wall" layout
 
 Then run this script in another shell to send colors to the simulator
 
-    example_clients/example.py
+    python_clients/example.py
 
 """
 

--- a/python_clients/lava_lamp.py
+++ b/python_clients/lava_lamp.py
@@ -13,7 +13,7 @@ First start the gl simulator using, for example, the included "wall" layout
 
 Then run this script in another shell to send colors to the simulator
 
-    example_clients/lava_lamp.py --layout layouts/wall.json
+    python_clients/lava_lamp.py --layout layouts/wall.json
 
 """
 

--- a/python_clients/miami.py
+++ b/python_clients/miami.py
@@ -13,7 +13,7 @@ First start the gl simulator using, for example, the included "wall" layout
 
 Then run this script in another shell to send colors to the simulator
 
-    example_clients/miami.py --layout layouts/wall.json
+    python_clients/miami.py --layout layouts/wall.json
 
 """
 

--- a/python_clients/nyan_cat.py
+++ b/python_clients/nyan_cat.py
@@ -13,7 +13,7 @@ First start the gl simulator using, for example, the included "wall" layout
 
 Then run this script in another shell to send colors to the simulator
 
-    example_clients/nyan_cat.py --layout layouts/wall.json
+    python_clients/nyan_cat.py --layout layouts/wall.json
 
 """
 

--- a/python_clients/sailor_moon.py
+++ b/python_clients/sailor_moon.py
@@ -13,7 +13,7 @@ First start the gl simulator using, for example, the included "wall" layout
 
 Then run this script in another shell to send colors to the simulator
 
-    example_clients/sailor_moon.py --layout layouts/wall.json
+    python_clients/sailor_moon.py --layout layouts/wall.json
 
 """
 

--- a/python_clients/spatial_stripes.py
+++ b/python_clients/spatial_stripes.py
@@ -15,7 +15,7 @@ First start the gl simulator using, for example, the included "wall" layout
 
 Then run this script in another shell to send colors to the simulator
 
-    example_clients/spatial_stripes.py --layout layouts/wall.json
+    python_clients/spatial_stripes.py --layout layouts/wall.json
 
 """
 


### PR DESCRIPTION
The folder structure is wrong in the examples. Updated to reflect the right folder so that the copy/paste one liners work.
