### PR TITLE
avoid closing the connection for zero-message-length packages.

### DIFF
--- a/src/opc_server.c
+++ b/src/opc_server.c
@@ -125,6 +125,8 @@ u8 opc_receive(opc_source source, opc_handler* handler, u32 timeout_ms) {
                       4 - info->header_length, 0);
       if (received > 0) {
         info->header_length += received;
+      } else if (received == 0) {  // connection was closed
+        received = -1;
       }
     } else {
       payload_expected = (info->header[2] << 8) | info->header[3];
@@ -133,6 +135,8 @@ u8 opc_receive(opc_source source, opc_handler* handler, u32 timeout_ms) {
                         payload_expected - info->payload_length, 0);
         if (received > 0) {
           info->payload_length += received;
+        } else if (received == 0) {  // connection was closed
+          received = -1;
         }
       }
       if (info->header_length == 4 &&
@@ -145,7 +149,7 @@ u8 opc_receive(opc_source source, opc_handler* handler, u32 timeout_ms) {
         info->payload_length = 0;
       }
     }
-    if (received <= 0) {
+    if (received < 0) {
       /* Connection was closed; wait for more connections. */
       fprintf(stderr, "OPC: Client closed connection\n");
       close(info->sock);


### PR DESCRIPTION
When the client sends a (useless) package with a zero lenght (i.e. no message data beyond the header) the opc-server inadvertedly closes the connection.

This patch fixes this behaviour, by explicitely checking if the recv() returned 0 (in this case the remote really has closed the connection) and setting "received" to -1 explicitely then.