### PR TITLE
Nate UDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ bin/
 # Kate temporary files
 *~
 *.kate-swp
+.vscode

--- a/debug.lldb
+++ b/debug.lldb
@@ -1,0 +1,2 @@
+b opc_server.c:57
+run -l layouts/freespace.json -t UDP

--- a/python/raver_plaid_parse.py
+++ b/python/raver_plaid_parse.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+"""A demo client for Open Pixel Control
+http://github.com/zestyping/openpixelcontrol
+
+Creates a shifting rainbow plaid pattern by overlaying different sine waves
+in the red, green, and blue channels.
+
+To run:
+First start the gl simulator using the included "wall" layout
+
+    make
+    bin/gl_server layouts/wall.json
+
+Then run this script in another shell to send colors to the simulator
+
+    python_clients/raver_plaid.py
+
+"""
+
+from __future__ import division
+import time
+import math
+import sys
+
+import opc
+import color_utils
+
+import optparse
+
+
+#-------------------------------------------------------------------------------
+# handle command line
+
+# The parser...
+parser = optparse.OptionParser()
+parser.add_option('-l', '--layout', dest='layout',
+                    action='store', type='string',
+                    help='layout file')
+parser.add_option('-s', '--server', dest='server', default='127.0.0.1:7890',
+                    action='store', type='string',
+                    help='ip and port of server')
+parser.add_option('-f', '--fps', dest='fps', default=20,
+                    action='store', type='int',
+                    help='frames per second')
+
+parser.add_option('-t', '--transport', dest='transport', default='UDP',
+                    action='store', type='string',
+                    help='specify transport, UDP or TCP')
+
+options, args = parser.parse_args()
+
+
+if len(sys.argv) == 1:
+    IP_PORT = '127.0.0.1:7890'
+else:
+    IP_PORT = options.server
+# elif len(sys.argv) == 2 and ':' in sys.argv[1] and not sys.argv[1].startswith('-'):
+#     IP_PORT = sys.argv[1]
+# else:
+#     print('''
+# Usage: raver_plaid.py [ip:port]
+#
+# If not set, ip:port defauls to 127.0.0.1:7890
+# ''')
+#     sys.exit(0)
+
+
+#-------------------------------------------------------------------------------
+# connect to server
+
+client = opc.Client(IP_PORT, socket_type=options.transport)
+if client.can_connect():
+    print('    connected to %s' % IP_PORT)
+else:
+    # can't connect, but keep running in case the server appears later
+    print('    WARNING: could not connect to %s' % IP_PORT)
+print('')
+
+
+#-------------------------------------------------------------------------------
+# send pixels
+
+print('    sending pixels forever (control-c to exit)...')
+print('')
+
+n_pixels = 1250  # number of pixels in the included "wall" layout
+fps = 60         # frames per second
+
+# how many sine wave cycles are squeezed into our n_pixels
+# 24 happens to create nice diagonal stripes on the wall layout
+freq_r = 24
+freq_g = 24
+freq_b = 24
+
+# how many seconds the color sine waves take to shift through a complete cycle
+speed_r = 7
+speed_g = -13
+speed_b = 19
+
+start_time = time.time()
+while True:
+    t = (time.time() - start_time) * 5
+    pixels = []
+    for ii in range(n_pixels):
+        pct = (ii / n_pixels)
+        # diagonal black stripes
+        pct_jittered = (pct * 77) % 37
+        blackstripes = color_utils.cos(pct_jittered, offset=t*0.05, period=1, minn=-1.5, maxx=1.5)
+        blackstripes_offset = color_utils.cos(t, offset=0.9, period=60, minn=-0.5, maxx=3)
+        blackstripes = color_utils.clamp(blackstripes + blackstripes_offset, 0, 1)
+        # 3 sine waves for r, g, b which are out of sync with each other
+        r = blackstripes * color_utils.remap(math.cos((t/speed_r + pct*freq_r)*math.pi*2), -1, 1, 0, 256)
+        g = blackstripes * color_utils.remap(math.cos((t/speed_g + pct*freq_g)*math.pi*2), -1, 1, 0, 256)
+        b = blackstripes * color_utils.remap(math.cos((t/speed_b + pct*freq_b)*math.pi*2), -1, 1, 0, 256)
+        pixels.append((r, g, b))
+    client.put_pixels(pixels, channel=0)
+    time.sleep(1 / fps)

--- a/src/gl_server.c
+++ b/src/gl_server.c
@@ -338,7 +338,7 @@ void load_layout(char* filename, int channel) {
   cJSON* start;
   cJSON* x2;
   int i = 0;
-  
+
   buffer = read_file(filename);
   if (buffer == NULL) {
 	  fprintf(stderr, "Unable to open '%s'\n", filename);
@@ -425,7 +425,7 @@ int main(int argc, char** argv) {
   int opt;
   char* layouts[MAX_CHANNELS];
 
-  while ((opt = getopt(argc, argv, ":hl:p:")) != -1)
+  while ((opt = getopt(argc, argv, ":hl:p:t:")) != -1)
   {
       switch (opt)
       {
@@ -439,6 +439,15 @@ int main(int argc, char** argv) {
           break;
       case 'p':
           port = strtol(optarg, NULL, 10);
+          break;
+      case 't':
+          if ( (strcmp(optarg, "UDP") == 0) || (strcmp(optarg, "TCP") == 0) ){
+            strcpy(transport, optarg);
+          }
+          else {
+            fprintf(stderr, "Transport can be UDP or TCP\n");
+            exit(1);
+          }
           break;
       case ':':
           fprintf(stderr, "Missing argument to option: '%c'\n", optopt);

--- a/src/opc.h
+++ b/src/opc.h
@@ -30,6 +30,9 @@ specific language governing permissions and limitations under the License. */
 /* Maximum number of pixels in one message */
 #define OPC_MAX_PIXELS_PER_MESSAGE ((1 << 16) / 3)
 
+// OPC global vars for options
+char transport[32]; // either "UDP" or "TCP"
+
 // OPC client functions ----------------------------------------------------
 
 /* Handle for an OPC sink created by opc_new_sink. */

--- a/src/opc_server.c
+++ b/src/opc_server.c
@@ -137,6 +137,7 @@ u8 opc_receive(opc_source source, opc_handler* handler, u32 timeout_ms) {
       info->header_length = 0;
       info->payload_length = 0;
     }
+    // Logic for handling data inbound on UDP connection
     else if (strcmp(transport, "UDP") == 0){
       fprintf(stderr, "UDP is connectionless. %s\n", buffer);
       info->sock = info->listen_sock;


### PR DESCRIPTION
UDP patch implementation.  This wasn't really well thought out, more of a hack, but I thought I'd share anyways.  Exposes option `-t` for selecting "UDP" || "TCP"

usage:

`python raver_plaid_parse.py -s 10.200.1.204:7890 -tUDP`
