### PR TITLE
Fix default OPC port usage in gl_server

### DIFF
--- a/src/gl_server.c
+++ b/src/gl_server.c
@@ -415,7 +415,7 @@ void usage(char* prog_name) {
 }
 
 int main(int argc, char** argv) {
-  u16 port;
+  u16 port = 0;
 
   glutInit(&argc, argv);
 


### PR DESCRIPTION
The _port_ variable is used uninitialized in line 463 when no port command line option is given, which in turn leads to a random port used by gl_server instead of the OPC default port.